### PR TITLE
Fix crash (when missing a dependency) where style tries to use wrong plugin name.

### DIFF
--- a/Source/MounteaAdvancedInventorySystemDeveloper/Private/Styling/MounteaAdvancedInventoryDeveloperStyle.cpp
+++ b/Source/MounteaAdvancedInventorySystemDeveloper/Private/Styling/MounteaAdvancedInventoryDeveloperStyle.cpp
@@ -31,7 +31,7 @@ void FMounteaAdvancedInventoryDeveloperStyle::Create()
 	const FVector2D Icon200x70(200.f, 70.f);
 	
 	StyleSet = MakeShareable(new FSlateStyleSet(GetAppStyleSetName()));
-	StyleSet->SetContentRoot(IPluginManager::Get().FindPlugin("MounteaDialogueSystem")->GetBaseDir() / TEXT("Resources"));
+	StyleSet->SetContentRoot(IPluginManager::Get().FindPlugin(TEXT("MounteaAdvancedInventorySystem"))->GetBaseDir() / TEXT("Resources"));
 
 	StyleSet->Set("MAISStyleSet.MounteaLogo.Small", new IMAGE_BRUSH(TEXT("Mountea_Logo"), Icon16x16));
 	StyleSet->Set("MAISStyleSet.MounteaLogo", new IMAGE_BRUSH(TEXT("Mountea_Logo"), Icon40x40));


### PR DESCRIPTION
If a user isn't using MounteaDialogueSystem, the style code crashes when trying to set the resources path to a missing dependency of MounteaDialogueSystem  rather than itself MounteaAdvancedInventorySystem (matches the .uplugin filename). 

I believe this fixes #175 , though now I'm getting a different crash via #176 which seems unrelated.